### PR TITLE
Add ability to pass a revision state for chained builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,18 @@
 
   <dependencies>
     <dependency>
+        <groupId>org.jvnet.hudson.plugins</groupId>
+        <artifactId>parameterized-trigger</artifactId>
+        <version>2.4</version>
+        <optional>true</optional>
+        <exclusions>
+            <exclusion>
+                <groupId>org.jvnet.hudson.plugins</groupId>
+                <artifactId>subversion</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.1</version>

--- a/src/main/java/hudson/plugins/repo/RepoRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/repo/RepoRevisionBuildParameters.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Krishnan Anantheswaran
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.repo;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
+//CS IGNORE LineLength FOR NEXT 1 LINES. REASON: class name too long
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameters.DontTriggerException;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * contributes a build parameter to the parameterized trigger plugin.
+ * Code closely follows the implementation in the git plugin.
+ */
+public class RepoRevisionBuildParameters extends AbstractBuildParameters {
+
+	private final boolean combineQueuedCommits;
+
+	/**
+	 * create a build parameters object.
+	 * @param combineQueuedCommits indicates if queued commits should be
+	 *							   combined
+	 */
+	@DataBoundConstructor
+	public RepoRevisionBuildParameters(final boolean combineQueuedCommits) {
+		this.combineQueuedCommits = combineQueuedCommits;
+	}
+
+	@Override
+	public Action getAction(final AbstractBuild<?, ?> abstractBuild,
+							final TaskListener taskListener)
+	throws IOException, InterruptedException, DontTriggerException {
+
+		final RevisionState state =
+				abstractBuild.getAction(RevisionState.class);
+
+		if (state == null) {
+			taskListener.getLogger().println(
+					"This project doesn't use repo as SCM."
+						+ "Can't pass the revision/ manifest to downstream");
+			return null;
+		}
+		return new RevisionParameterAction(state, combineQueuedCommits);
+	}
+
+	/**
+	 * Descriptor for this class.
+	 */
+	@Extension(optional = true)
+	public static class DescriptorImpl
+			extends Descriptor<AbstractBuildParameters> {
+		@Override
+		public String getDisplayName() {
+			return "Pass-through repo revision and manifest";
+		}
+	}
+}
+
+

--- a/src/main/java/hudson/plugins/repo/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/repo/RevisionParameterAction.java
@@ -1,0 +1,149 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Krishnan Anantheswaran
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.repo;
+
+import hudson.Util;
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Queue;
+import hudson.model.Queue.QueueAction;
+import hudson.model.queue.FoldableAction;
+
+import java.io.Serializable;
+import java.util.List;
+
+
+/**
+ * Used as a build parameter to specify the revision to be built.
+ * Code closely follows the implementation in the git plugin.
+ */
+public class RevisionParameterAction extends InvisibleAction
+		implements Serializable, QueueAction, FoldableAction {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String manifest;
+	private final String manifestRevision;
+	private final boolean combineCommits;
+
+	/**
+	 * constructs a parameterized action from a revision state.
+	 * @param state the revision state
+	 * @param combineCommits true to indicate that commits should be combined
+	 */
+	public RevisionParameterAction(final RevisionState state,
+								   final boolean combineCommits) {
+		this.manifest = state.getManifest();
+		this.manifestRevision = state.getManifestRevision();
+		this.combineCommits = combineCommits;
+	}
+
+	/**
+	 * returns the local manifest associated with the revision state.
+	 */
+	public String getManifest() {
+		return manifest;
+	}
+
+	/**
+	 * returns the revision of the manifest as a SHA.
+	 */
+	public String getManifestRevision() {
+		return manifestRevision;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString()
+				+ "[rev=" + manifestRevision + ";manifest=" + manifest + "]";
+	}
+
+	/**
+	 * Returns whether the new item should be scheduled.
+	 * An action should return true if the associated task is
+	 * 'different enough' to warrant a separate execution.
+	 * from {@link QueueAction}
+	 * @param actions the list of actions
+	  */
+	public boolean shouldSchedule(final List<Action> actions) {
+		/* Called in two cases
+		1. On the action attached to an existing queued item
+		2. On the action attached to the new item to add.
+		Behaviour
+		If actions contain a RevisionParameterAction with a matching commit
+		to this one, we do not need to schedule
+		in all other cases we do.
+		*/
+		final List<RevisionParameterAction> otherActions =
+				Util.filter(actions, RevisionParameterAction.class);
+		if (combineCommits) {
+			// we are combining commits so we never need to schedule
+			// another run.
+			// unless other job does not have a RevisionParameterAction
+			// (manual build)
+			if (otherActions.size() != 0) {
+				return false;
+			}
+		} else {
+			for (RevisionParameterAction action : otherActions) {
+				if (this.manifest.equals(action.manifest)
+						&& this.manifestRevision.equals(
+							action.manifestRevision)) {
+					return false;
+				}
+			}
+		}
+		// if we get to this point there were no matching actions
+		// so a new build is required
+		return true;
+	}
+
+	/**
+	 * Folds this Action into another action already associated with item.
+	 * from {@link FoldableAction}
+	 * @param item the queue item
+	 * @param owner the task owner
+	 * @param otherActions the list of other actions with which ti potentially
+	 *					   fold this one
+	 */
+	public void foldIntoExisting(final Queue.Item item, final Queue.Task owner,
+								 final List<Action> otherActions) {
+		// only do this if we are asked to.
+		if (combineCommits) {
+			final RevisionParameterAction existing =
+					item.getAction(RevisionParameterAction.class);
+			if (existing != null) {
+				//because we cannot modify the commit in the existing action
+				// remove it and add self
+				item.getActions().remove(existing);
+				item.getActions().add(this);
+				return;
+			}
+			// no CauseAction found, so add a copy of this one
+			item.getActions().add(this);
+		}
+	}
+
+}
+

--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -52,6 +52,8 @@ import org.xml.sax.InputSource;
 @SuppressWarnings("serial")
 public class RevisionState extends SCMRevisionState implements Serializable {
 
+	private static final String MANIFEST_REVISION_PATH = ".repo/manifests.git";
+
 	private final String manifest;
 	private final Map<String, ProjectState> projects =
 			new TreeMap<String, ProjectState>();
@@ -115,7 +117,7 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 				}
 			}
 
-            final String manifestP = ".repo/manifests.git";
+            final String manifestP = MANIFEST_REVISION_PATH;
             projects.put(manifestP, ProjectState.constructCachedInstance(
                         manifestP, manifestP, manifestRevision));
             if (logger != null) {
@@ -179,6 +181,13 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 		return project == null ? null : project.getRevision();
 	}
 
+	/**
+	 * returns the manifest revision for this state.
+	 */
+	public String getManifestRevision() {
+		ProjectState project = projects.get(MANIFEST_REVISION_PATH);
+		return project == null ? null : project.getRevision();
+	}
 	/**
 	 * Calculate what has changed from a specified previous repository state.
 	 *

--- a/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright (c) 2014, Krishnan Anantheswaran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry field="combineQueuedCommits"
+             title="${%Combine Queued repo manifests}">
+      <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/help-combineQueuedCommits.html
+++ b/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/help-combineQueuedCommits.html
@@ -1,0 +1,4 @@
+<div>
+  This checkbox cause the all revisions to be be ignored apart from the last one if a build is already in the queue.<br/>
+  Does not combine entries with builds of manually started downstream job that are queued. (Ones that do no have a repo state attached to them)<br/>
+</div>

--- a/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/help.html
+++ b/src/main/resources/hudson/plugins/repo/RepoRevisionBuildParameters/help.html
@@ -1,0 +1,6 @@
+<div>
+  This "parameter" passes the repo revision and the expanded manifest built by
+  this project into the specified job, and thereby causes the specified job to
+  check out the exact same source tree for all repositories. This is useful to chain
+  multiple activities in a sequence that acts on the same commit in different ways.
+</div>


### PR DESCRIPTION
This is how it works:

A `RevisionParameterAction` instance can be created as a parameterized action. It holds on to 2 things
- The checkout SHA of the manifest repository
- The contents of the upstream manifest with revisions expanded (using `repo manifest -r`)

When passed to the downstream build, this is what roughly happens:

```
$ # RESOLVED_MANIFEST -> resolved manifest from upstream build
$ # MANIFEST_URL -> original git URL of the manifest repo
$ # MANIFEST_SHA -> SHA of the manifest repo at the time of upstream build pull
$ DYNAMIC_FILE=override-`generate-suffix`.xml
$ mkdir -p .repo/manifests
$ echo $RESOLVED_MANIFEST > .repo/manifests/$DYNAMIC_FILE
$ repo init -u $MANIFEST_URL -b $MANIFEST_SHA  -m $DYNAMIC_FILE
$ repo sync -d
```
